### PR TITLE
Switch badgeds for dragons.

### DIFF
--- a/src/components/Dragons.js
+++ b/src/components/Dragons.js
@@ -34,8 +34,11 @@ export default function Dragons() {
                 description={dragon.description}
                 img={dragon.img}
               />
-              <button className="reserveDragon" type="button" onClick={() => handleReserve(dragon.id)}>Reserve Dragon</button>
-              <button className="cancelDragon" type="button" onClick={() => handleUnreserve(dragon.id)}>Cancel Reservation</button>
+              {dragon.reserved ? (
+                <button className="cancelDragon" type="button" onClick={() => handleUnreserve(dragon.id)}>Cancel Reservation</button>
+              ) : (
+                <button className="reserveDragon" type="button" onClick={() => handleReserve(dragon.id)}>Reserve Dragon</button>
+              )}
             </div>
           ))
         }


### PR DESCRIPTION
- Dragons that have already been reserved should show a "Reserved" badge and "Cancel reservation" button instead of the default "Reserve dragon" (as per design).